### PR TITLE
Fix oVirt datacenter name to UUID conversion in API

### DIFF
--- a/app/controllers/concerns/foreman_ovirt/api_compute_resources_controller_extension.rb
+++ b/app/controllers/concerns/foreman_ovirt/api_compute_resources_controller_extension.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module ForemanOvirt
+  module ApiComputeResourcesControllerExtension
+    extend ActiveSupport::Concern
+
+    included do
+      # rubocop:disable Rails/LexicallyScopedActionFilter
+      before_action :convert_datacenter_to_uuid, only: %i[create update]
+      # rubocop:enable Rails/LexicallyScopedActionFilter
+    end
+
+    private
+
+    def convert_datacenter_to_uuid
+      datacenter = params[:compute_resource][:datacenter]
+      return if datacenter.blank? || Foreman.is_uuid?(datacenter)
+
+      case params[:action]
+      when 'create'
+        return unless compute_resource_params[:provider]&.downcase == 'ovirt'
+        @compute_resource = ComputeResource.new_provider(compute_resource_params.except(:datacenter))
+      when 'update'
+        return unless @compute_resource.is_a?(ForemanOvirt::Ovirt)
+      else
+        Rails.logger.error("Convert datacenter to UUID should not be called for action #{params[:action]}")
+        return
+      end
+
+      uuid = change_datacenter_to_uuid(datacenter)
+      params[:compute_resource][:datacenter] = uuid if uuid.present?
+    rescue Foreman::Exception => e
+      render_exception(e, status: :unprocessable_entity)
+      false
+    end
+
+    def change_datacenter_to_uuid(datacenter)
+      @compute_resource.test_connection
+      @compute_resource.get_datacenter_uuid(datacenter)
+    end
+  end
+end

--- a/lib/foreman_ovirt/engine.rb
+++ b/lib/foreman_ovirt/engine.rb
@@ -61,6 +61,7 @@ module ForemanOvirt
 
       ::ComputeResourcesVmsController.include ForemanOvirt::ComputeResourcesVmsController
       ::ComputeResourcesController.include ForemanOvirt::ParametersExtension
+      ::Api::V2::ComputeResourcesController.include ForemanOvirt::ApiComputeResourcesControllerExtension
     rescue StandardError => e
       Rails.logger.warn "ForemanOvirt: skipping engine hook (#{e})"
     end

--- a/test/controllers/api/v2/compute_resources_controller_test.rb
+++ b/test/controllers/api/v2/compute_resources_controller_test.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+
+require 'test_plugin_helper'
+require 'fog/ovirt/models/compute/quota'
+
+module Api
+  module V2
+    # rubocop:disable Metrics/ClassLength
+    class OvirtComputeResourcesControllerTest < ActionController::TestCase
+      # rubocop:enable Metrics/ClassLength
+      tests Api::V2::ComputeResourcesController
+
+      def setup
+        Fog.mock!
+      end
+
+      def teardown
+        Fog.unmock!
+      end
+
+      context 'ovirt available resources' do
+        setup do
+          @ovirt_object = Object.new
+          @ovirt_object.stubs(:name).returns('test_ovirt_object')
+          @ovirt_object.stubs(:id).returns('my11-test35-uuid99')
+
+          quota = Fog::Ovirt::Compute::Quota.new(id: '1', name: 'Default')
+          client_mock = mock.tap { |m| m.stubs(datacenters: [], quotas: [quota], servers: []) }
+          ForemanOvirt::Ovirt.any_instance.stubs(:client).returns(client_mock)
+
+          @ovirt_cr = FactoryBot.create(:ovirt_cr)
+        end
+
+        teardown do
+          if @response.present? && @response.code.to_i.between?(200, 299)
+            available_objects = ActiveSupport::JSON.decode(@response.body)
+            assert_not_empty available_objects
+          end
+        end
+
+        test 'should get available virtual machines' do
+          ForemanOvirt::Ovirt.any_instance.stubs(:available_virtual_machines).returns([@ovirt_object])
+          get :available_virtual_machines, params: { id: @ovirt_cr.to_param }
+        end
+
+        test 'should get available networks' do
+          ForemanOvirt::Ovirt.any_instance.stubs(:available_networks).returns([@ovirt_object])
+          get :available_networks, params: { id: @ovirt_cr.to_param, cluster_id: '123-456-789' }
+        end
+
+        test 'should get available clusters' do
+          ForemanOvirt::Ovirt.any_instance.stubs(:available_clusters).returns([@ovirt_object])
+          get :available_clusters, params: { id: @ovirt_cr.to_param }
+        end
+
+        test 'should get available storage domains' do
+          ForemanOvirt::Ovirt.any_instance.stubs(:available_storage_domains).returns([@ovirt_object])
+          get :available_storage_domains, params: { id: @ovirt_cr.to_param }
+        end
+      end
+
+      context 'ovirt datacenters' do
+        setup do
+          quota = Fog::Ovirt::Compute::Quota.new(id: '1', name: 'Default')
+          client_mock = mock.tap { |m| m.stubs(datacenters: [], quotas: [quota], servers: []) }
+          ForemanOvirt::Ovirt.any_instance.stubs(:client).returns(client_mock)
+        end
+
+        test 'should create with datacenter name' do
+          datacenter_uuid = Foreman.uuid
+          ForemanOvirt::Ovirt.any_instance.stubs(:get_datacenter_uuid).returns(datacenter_uuid)
+          ForemanOvirt::Ovirt.any_instance.stubs(:test_connection).returns(true)
+
+          attrs = { name: 'Ovirt-create-test', url: 'https://myovirt/api', provider: 'ovirt',
+                    datacenter: 'test', user: 'user@example.com', password: 'secret' }
+          post :create, params: { compute_resource: attrs }
+
+          assert_response :created
+          assert_equal datacenter_uuid, ActiveSupport::JSON.decode(@response.body)['datacenter']
+        end
+
+        test 'should create with datacenter uuid' do
+          datacenter_uuid = Foreman.uuid
+          # Implicitly tests that conversion is skipped
+          ForemanOvirt::Ovirt.any_instance.expects(:get_datacenter_uuid).never
+
+          attrs = { name: 'Ovirt-create-test', url: 'https://myovirt/api', provider: 'ovirt',
+                    datacenter: datacenter_uuid, user: 'user@example.com', password: 'secret' }
+          post :create, params: { compute_resource: attrs }
+
+          assert_response :created
+          assert_equal datacenter_uuid, ActiveSupport::JSON.decode(@response.body)['datacenter']
+        end
+
+        test 'should update with datacenter name' do
+          datacenter_uuid = Foreman.uuid
+          compute_resource = FactoryBot.create(:ovirt_cr)
+
+          ForemanOvirt::Ovirt.any_instance.stubs(:get_datacenter_uuid).returns(datacenter_uuid)
+          ForemanOvirt::Ovirt.any_instance.stubs(:test_connection).returns(true)
+
+          attrs = { datacenter: 'test' }
+          put :update, params: { id: compute_resource.id, compute_resource: attrs }
+
+          assert_response :ok
+          assert_equal datacenter_uuid, ActiveSupport::JSON.decode(@response.body)['datacenter']
+        end
+
+        test 'should update with datacenter uuid' do
+          datacenter_uuid = Foreman.uuid
+          compute_resource = FactoryBot.create(:ovirt_cr)
+
+          # Implicitly tests that conversion is skipped
+          ForemanOvirt::Ovirt.any_instance.expects(:get_datacenter_uuid).never
+
+          attrs = { datacenter: datacenter_uuid }
+          put :update, params: { id: compute_resource.id, compute_resource: attrs }
+
+          assert_response :ok
+          assert_equal datacenter_uuid, ActiveSupport::JSON.decode(@response.body)['datacenter']
+        end
+
+        test 'should handle datacenter conversion failure' do
+          exception_msg = 'Datacenter not found or Auth failed'
+          ForemanOvirt::Ovirt.any_instance.stubs(:test_connection).raises(Foreman::Exception.new(exception_msg))
+
+          attrs = { name: 'Ovirt-rescue-test', url: 'https://myovirt/api', provider: 'ovirt',
+                    datacenter: 'Failing-DC', user: 'user@example.com', password: 'secret' }
+          post :create, params: { compute_resource: attrs }
+
+          assert_response :unprocessable_entity
+        end
+
+        test 'should skip conversion safely if datacenter is completely omitted or blank' do
+          ForemanOvirt::Ovirt.any_instance.expects(:get_datacenter_uuid).never
+          attrs = { name: 'Ovirt-omitted-test', url: 'https://myovirt/api', provider: 'ovirt',
+                    user: 'user@example.com', password: 'secret' }
+          post :create, params: { compute_resource: attrs }
+
+          assert_response :created
+          assert_nil ActiveSupport::JSON.decode(@response.body)['datacenter']
+        end
+
+        test 'should skip datacenter conversion if provider is not ovirt' do
+          ForemanOvirt::Ovirt.any_instance.expects(:get_datacenter_uuid).never
+
+          attrs = { name: 'Non-Ovirt-test', url: 'qemu:///system', provider: 'Libvirt', datacenter: 'leave-me-alone' }
+          post :create, params: { compute_resource: attrs }
+
+          assert_equal 'leave-me-alone', @controller.params[:compute_resource][:datacenter]
+        end
+
+        test 'should handle provider name with different casing' do
+          datacenter_uuid = Foreman.uuid
+          ForemanOvirt::Ovirt.any_instance.stubs(:get_datacenter_uuid).returns(datacenter_uuid)
+          ForemanOvirt::Ovirt.any_instance.stubs(:test_connection).returns(true)
+
+          attrs = { name: 'Ovirt-uppercase-test', url: 'https://myovirt/api', provider: 'OVIRT',
+                    datacenter: 'test', user: 'user@example.com', password: 'secret' }
+          post :create, params: { compute_resource: attrs }
+
+          assert_response :created
+          assert_equal datacenter_uuid, ActiveSupport::JSON.decode(@response.body)['datacenter']
+        end
+      end
+
+      test 'should skip datacenter conversion on update if provider is not ovirt' do
+        compute_resource = FactoryBot.create(:vmware_cr)
+        ForemanOvirt::Ovirt.any_instance.expects(:get_datacenter_uuid).never
+
+        attrs = { datacenter: 'leave-me-alone' }
+        put :update, params: { id: compute_resource.id, compute_resource: attrs }
+
+        assert_equal 'leave-me-alone', @controller.params[:compute_resource][:datacenter]
+      end
+
+      context 'ovirt cache refreshing' do
+        test 'should fail if unsupported' do
+          ovirt_cr = FactoryBot.create(:ovirt_cr)
+          put :refresh_cache, params: { id: ovirt_cr.to_param }
+          assert_response :error
+        end
+      end
+    end
+  end
+end

--- a/test/models/compute_resources/ovirt_test.rb
+++ b/test/models/compute_resources/ovirt_test.rb
@@ -664,5 +664,24 @@ module ForemanOvirt
         assert_equal 'false', attrs[:volumes_attributes]['0'][:wipe_after_delete]
       end
     end
+
+    describe '#get_datacenter_uuid' do
+      test 'resolves datacenter name from datacenters list' do
+        uuid = Foreman.uuid
+        cr = FactoryBot.build(:ovirt_cr)
+        cr.stubs(:datacenters).returns([
+                                         ['prod', uuid],
+                                         ['dev', Foreman.uuid],
+                                       ])
+        assert_equal uuid, cr.get_datacenter_uuid('prod')
+      end
+
+      test 'raises when datacenter is unknown' do
+        cr = FactoryBot.build(:ovirt_cr)
+        cr.stubs(:datacenters).returns([['dev', Foreman.uuid]])
+        error = assert_raise(Foreman::Exception) { cr.get_datacenter_uuid('prod') }
+        assert_match(/Datacenter was not found/, error.message)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR restores the logic that converts an oVirt Datacenter name into a UUID during API create and update requests for Compute Resources.

Why it is needed:
While migrating the Compute Resources API tests to foreman_ovirt, we discovered that passing a Datacenter string name (instead of a UUID) resulted in the API saving and returning the raw string. In Foreman core, the translation logic to fetch the UUID lived directly inside the [Api::V2::ComputeResourcesController's](https://github.com/theforeman/foreman/blob/f2aef855824f6a70cde80b28770dacffed1ead9c/app/controllers/api/v2/compute_resources_controller.rb#L66) create and update actions. During the plugin extraction, this specific piece of logic was lost.

How it was implemented:

- This PR introduces a new controller concern (ForemanOvirt::ApiComputeResourcesControllerExtension).
- We use a before_action hook to cleanly intercept create and update requests.
- The hook checks if the resource is an oVirt provider.
- If a string name is provided for the datacenter, it connects to oVirt, fetches the UUID, and mutates params[:compute_resource][:datacenter].
- Control is then passed back to the core Foreman controller, which saves the correct UUID.
- Also, this migrates `test/controllers/api/v2/compute_resources_controller_test.rb` from Foreman core, introducing comprehensive test coverage for the new extension logic, guard clauses, and error handling.