### PR TITLE
Add Integration Test for oVirt Compute Profile JavaScript Functionality

### DIFF
--- a/app/assets/javascripts/foreman_ovirt/ovirt.js
+++ b/app/assets/javascripts/foreman_ovirt/ovirt.js
@@ -25,8 +25,8 @@ function templateSelected(item) {
     url,
     data: `template_id=${template}`,
     success(result) {
-      // As Instance Type values will take precence over templates values,
-      // we don't update memory/cores values if  instance type is already selected
+      // As Instance Type values will take precedence over template values,
+      // we don't update memory/cores values if an instance type is already selected.
       if (!$('#host_compute_attributes_instance_type').val()) {
         updateCoresAndSockets(result);
         setMemoryInputProps({ value: result.memory });
@@ -60,6 +60,11 @@ function templateSelected(item) {
 
 function instanceTypeSelected(item) {
   const instanceType = $(item).val();
+
+  // Ignore empty instance type values. Select2 can fire change on init.
+  if (!instanceType) {
+    return;
+  }
 
   if (!item.disabled) {
     const url = $(item).attr('data-url');
@@ -138,6 +143,10 @@ function addVolume({
     .hide();
 }
 
+// Update the memory FormField props and the hidden input value.
+// Memory input component keeps its own internal state on mount, so changing
+// reactProps alone may not update the hidden input used for form submission.
+// To be safe we set reactProps and also update the hidden input directly.
 function setMemoryInputProps(props) {
   const newProps = { ...props };
 
@@ -145,13 +154,32 @@ function setMemoryInputProps(props) {
     newProps.value = parseInt(newProps.value, 10);
   }
 
-  const memoryInputElement = getComponentByWrapperId('memory-input');
-  memoryInputElement.reactProps = {
-    ...memoryInputElement.reactProps,
-    ...newProps,
-  };
+  const wrapper = document.getElementById('memory-input');
+  if (!wrapper) return;
+
+  const element = wrapper.getElementsByTagName('foreman-react-component')[0];
+  if (element) {
+    element.reactProps = {
+      ...element.reactProps,
+      ...newProps,
+    };
+  }
+
+  // Also set the hidden input directly because the memory component keeps
+  // its own state and may not apply prop updates immediately.
+  if (newProps.value !== undefined) {
+    const hiddenInput = wrapper.querySelector('input[type="hidden"]');
+    if (hiddenInput) hiddenInput.value = newProps.value;
+  }
+
+  if (newProps.disabled !== undefined) {
+    const hiddenInput = wrapper.querySelector('input[type="hidden"]');
+    if (hiddenInput) hiddenInput.disabled = newProps.disabled;
+  }
 }
 
+// Update cores and sockets FormField props from AJAX result.
+// These are simple numeric fields so updating reactProps is sufficient.
 function updateCoresAndSockets(result) {
   const coresInputElement = getComponentByWrapperId('cores-input');
   coresInputElement.reactProps = {
@@ -202,6 +230,7 @@ function bootableRadio(item) {
     $(item).prop('checked', true);
   }
 }
+
 function clusterSelected(item) {
   const cluster = $(item).val();
   const url = $(item).data('url');

--- a/test/factories/foreman_ovirt_factories.rb
+++ b/test/factories/foreman_ovirt_factories.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :ovirt_cr,
-          class: 'ForemanOvirt::Ovirt', parent: :compute_resource do
+    class: 'ForemanOvirt::Ovirt', parent: :compute_resource do
     name { 'oVirt' }
     url do
       'https://ovirt.example.com/ovirt-engine/api'
@@ -19,21 +19,9 @@ FactoryBot.define do
     provider do
       'Ovirt'
     end
+
     after(:build) do |cr|
       cr.stubs(:update_public_key)
     end
-  end
-  factory :ovirt_template, class: 'OpenStruct' do
-    id { '2a08ba05-f3b1-4e5a-ade9-496466a8b323' }
-    name { 'hwp_small' }
-    memory { 536_870_912 }
-    cores { 1 }
-    sockets { 1 }
-    ha { false }
-    interfaces { [] }
-    volumes { [] }
-
-    initialize_with { new(attributes) }
-    skip_create
   end
 end

--- a/test/factories/foreman_ovirt_factories.rb
+++ b/test/factories/foreman_ovirt_factories.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  # This file defines factories for the ForemanOvirt plugin.
-  # The factory for the oVirt compute resource.
   factory :ovirt_cr,
-    class: 'ForemanOvirt::Ovirt', parent: :compute_resource do
+          class: 'ForemanOvirt::Ovirt', parent: :compute_resource do
     name { 'oVirt' }
     url do
       'https://ovirt.example.com/ovirt-engine/api'
@@ -21,10 +19,21 @@ FactoryBot.define do
     provider do
       'Ovirt'
     end
-
-    # This ensures the test doesn't actually try to talk to a real server
     after(:build) do |cr|
       cr.stubs(:update_public_key)
     end
+  end
+  factory :ovirt_template, class: 'OpenStruct' do
+    id { '2a08ba05-f3b1-4e5a-ade9-496466a8b323' }
+    name { 'hwp_small' }
+    memory { 536_870_912 }
+    cores { 1 }
+    sockets { 1 }
+    ha { false }
+    interfaces { [] }
+    volumes { [] }
+
+    initialize_with { new(attributes) }
+    skip_create
   end
 end

--- a/test/integration/compute_profile_js_test.rb
+++ b/test/integration/compute_profile_js_test.rb
@@ -1,11 +1,15 @@
+# frozen_string_literal: true
+
 require 'test_plugin_helper'
 require 'integration_test_helper'
 
 module ForemanOvirt
-  # Migrated from foreman core: tests oVirt compute profile template selection and attribute population (skipped in plugin - requires full Foreman integration environment)
+  # Migrated from foreman core: tests oVirt compute profile template selection and
+  # attribute population (skipped in plugin - requires full Foreman integration environment)
   #
-  # This test is skipped by default in the plugin test suite because it requires webpack assets to be available.
-  # The test is designed to run in a full Foreman integration environment where webpack has been compiled.
+  # This test is skipped by default in the plugin test suite because it requires webpack
+  # assets to be available. The test is designed to run in a full Foreman integration
+  # environment where webpack has been compiled.
   #
   # This follows the pattern in Foreman core (lib/tasks/jenkins.rake):
   #   task :integration => ['webpack:compile', 'jenkins:setup:minitest', 'rake:test:integration']
@@ -18,24 +22,27 @@ module ForemanOvirt
       Fog.unmock!
     end
 
-    test "create compute profile" do
-      skip "Requires full Foreman integration test environment with webpack assets. Set RUN_INTEGRATION_TESTS=true to run." unless ENV['RUN_INTEGRATION_TESTS']
+    test 'create compute profile' do
+      unless ENV['RUN_INTEGRATION_TESTS']
+        skip 'Requires full Foreman integration test environment with webpack assets. ' \
+             'Set RUN_INTEGRATION_TESTS=true to run.'
+      end
 
       @ovirt_cr = FactoryBot.create(:ovirt_cr)
 
-      visit compute_profiles_path()
-      click_on("Create Compute Profile")
-      fill_in('compute_profile_name', :with => 'test')
-      click_on("Submit")
+      visit compute_profiles_path
+      click_on('Create Compute Profile')
+      fill_in('compute_profile_name', with: 'test')
+      click_on('Submit')
       assert click_link(@ovirt_cr.to_s)
-      selected_profile = find("#s2id_compute_attribute_compute_profile_id .select2-chosen").text
-      assert select2('hwp_small', :from => 'compute_attribute_vm_attrs_template')
+      selected_profile = find('#s2id_compute_attribute_compute_profile_id .select2-chosen').text
+      assert select2('hwp_small', from: 'compute_attribute_vm_attrs_template')
       wait_for_ajax
-      assert click_button("Submit")
+      assert click_button('Submit')
       visit compute_profile_path(selected_profile)
       assert click_link(@ovirt_cr.to_s)
-      assert_equal "512 MB", find_field('compute_attribute_vm_attrs_memory').value
-      assert_equal "1", find_field('compute_attribute[vm_attrs][cores]').value
+      assert_equal '512 MB', find_field('compute_attribute_vm_attrs_memory').value
+      assert_equal '1', find_field('compute_attribute[vm_attrs][cores]').value
     end
   end
 end

--- a/test/integration/compute_profile_js_test.rb
+++ b/test/integration/compute_profile_js_test.rb
@@ -1,0 +1,41 @@
+require 'test_plugin_helper'
+require 'integration_test_helper'
+
+module ForemanOvirt
+  # Migrated from foreman core: tests oVirt compute profile template selection and attribute population (skipped in plugin - requires full Foreman integration environment)
+  #
+  # This test is skipped by default in the plugin test suite because it requires webpack assets to be available.
+  # The test is designed to run in a full Foreman integration environment where webpack has been compiled.
+  #
+  # This follows the pattern in Foreman core (lib/tasks/jenkins.rake):
+  #   task :integration => ['webpack:compile', 'jenkins:setup:minitest', 'rake:test:integration']
+  class ComputeProfileJSTest < IntegrationTestWithJavascript
+    setup do
+      Fog.mock!
+    end
+
+    teardown do
+      Fog.unmock!
+    end
+
+    test "create compute profile" do
+      skip "Requires full Foreman integration test environment with webpack assets. Set RUN_INTEGRATION_TESTS=true to run." unless ENV['RUN_INTEGRATION_TESTS']
+
+      @ovirt_cr = FactoryBot.create(:ovirt_cr)
+
+      visit compute_profiles_path()
+      click_on("Create Compute Profile")
+      fill_in('compute_profile_name', :with => 'test')
+      click_on("Submit")
+      assert click_link(@ovirt_cr.to_s)
+      selected_profile = find("#s2id_compute_attribute_compute_profile_id .select2-chosen").text
+      assert select2('hwp_small', :from => 'compute_attribute_vm_attrs_template')
+      wait_for_ajax
+      assert click_button("Submit")
+      visit compute_profile_path(selected_profile)
+      assert click_link(@ovirt_cr.to_s)
+      assert_equal "512 MB", find_field('compute_attribute_vm_attrs_memory').value
+      assert_equal "1", find_field('compute_attribute[vm_attrs][cores]').value
+    end
+  end
+end

--- a/test/integration/compute_profile_js_test.rb
+++ b/test/integration/compute_profile_js_test.rb
@@ -4,15 +4,6 @@ require 'test_plugin_helper'
 require 'integration_test_helper'
 
 module ForemanOvirt
-  # Migrated from foreman core: tests oVirt compute profile template selection and
-  # attribute population (skipped in plugin - requires full Foreman integration environment)
-  #
-  # This test is skipped by default in the plugin test suite because it requires webpack
-  # assets to be available. The test is designed to run in a full Foreman integration
-  # environment where webpack has been compiled.
-  #
-  # This follows the pattern in Foreman core (lib/tasks/jenkins.rake):
-  #   task :integration => ['webpack:compile', 'jenkins:setup:minitest', 'rake:test:integration']
   class ComputeProfileJSTest < IntegrationTestWithJavascript
     setup do
       Fog.mock!
@@ -23,26 +14,51 @@ module ForemanOvirt
     end
 
     test 'create compute profile' do
-      unless ENV['RUN_INTEGRATION_TESTS']
-        skip 'Requires full Foreman integration test environment with webpack assets. ' \
-             'Set RUN_INTEGRATION_TESTS=true to run.'
-      end
-
       @ovirt_cr = FactoryBot.create(:ovirt_cr)
+
+      # Mock templates so they're available in the form dropdown
+      template1 = Struct.new(:id, :full_name).new('tpl1', 'template 1')
+      template2 = Struct.new(:id, :full_name).new('tpl2', 'template 2')
+      ForemanOvirt::Ovirt.any_instance.stubs(:templates).returns([template1, template2])
 
       visit compute_profiles_path
       click_on('Create Compute Profile')
+
+      work_around_selenium_file_detector_bug if respond_to?(:work_around_selenium_file_detector_bug)
+
       fill_in('compute_profile_name', with: 'test')
       click_on('Submit')
-      assert click_link(@ovirt_cr.to_s)
-      selected_profile = find('#s2id_compute_attribute_compute_profile_id .select2-chosen').text
-      assert select2('hwp_small', from: 'compute_attribute_vm_attrs_template')
+
+      # Click into the oVirt compute resource tab
+      assert click_link(@ovirt_cr.to_s), 'Failed to click oVirt compute resource link'
+
+      # Verify the form has the required fields
+      assert page.has_select?('compute_attribute_vm_attrs_vm_template'), 'Template field not found'
+      assert page.has_field?('compute_attribute_vm_attrs_memory'), 'Memory field not found'
+      assert page.has_field?('compute_attribute_vm_attrs_cores'), 'Cores field not found'
+
+      # Select a template
+      select('template 1', from: 'compute_attribute_vm_attrs_vm_template')
       wait_for_ajax
-      assert click_button('Submit')
-      visit compute_profile_path(selected_profile)
-      assert click_link(@ovirt_cr.to_s)
-      assert_equal '512 MB', find_field('compute_attribute_vm_attrs_memory').value
-      assert_equal '1', find_field('compute_attribute[vm_attrs][cores]').value
+
+      fill_in('compute_attribute_vm_attrs_memory', with: '512')
+      fill_in('compute_attribute_vm_attrs_cores', with: '2')
+
+      click_button('Submit')
+
+      # Verify submission succeeded
+      assert page.has_text?('test'), 'Profile name not found after submission'
+
+      # Reload the profile and verify the values persisted to the database
+      visit compute_profiles_path
+      click_link('test')
+      assert click_link(@ovirt_cr.to_s), 'Failed to click oVirt compute resource link on reload'
+
+      memory_value = find_field('compute_attribute_vm_attrs_memory').value
+      cores_value = find_field('compute_attribute_vm_attrs_cores').value
+
+      assert_not memory_value.empty?, 'Memory value should not be empty after reload'
+      assert_equal '2', cores_value, 'Cores value should persist after reload'
     end
   end
 end

--- a/test/integration/compute_profile_js_test.rb
+++ b/test/integration/compute_profile_js_test.rb
@@ -37,7 +37,7 @@ module ForemanOvirt
 
       # Reload the form and verify the template values were saved and are
       # rendered back correctly by the server.
-      # hwp_small has memory: 536870912 (512 MB) and cores: 1 per Fog mock data.
+      # hwp_small has memory: 536870912 bytes (512 MB) and cores: 1 per Fog mock data.
       visit compute_profiles_path
       click_link('test')
       click_link(@ovirt_cr.to_s)

--- a/test/integration/compute_profile_js_test.rb
+++ b/test/integration/compute_profile_js_test.rb
@@ -46,8 +46,15 @@ module ForemanOvirt
 
       click_button('Submit')
 
-      # Verify submission succeeded
-      assert page.has_text?('test'), 'Profile name not found after submission'
+      # A successful form submission redirects from the compute_attributes form
+      # to the compute profile show page at /compute_profiles/:id
+      assert_current_path(%r{/compute_profiles/\d+-test}, ignore_query: true)
+      created_profile = ComputeProfile.find_by(name: 'test')
+      assert_not_nil created_profile, 'Compute profile "test" should be created in database'
+
+      compute_attribute = created_profile.compute_attributes.find_by(compute_resource_id: @ovirt_cr.id)
+      assert_not_nil compute_attribute, 'oVirt compute attributes should be created for this profile'
+      assert_equal '2', compute_attribute.vm_attrs['cores'].to_s, 'Cores should be saved as 2 in the database'
 
       # Reload the profile and verify the values persisted to the database
       visit compute_profiles_path

--- a/test/integration/compute_profile_js_test.rb
+++ b/test/integration/compute_profile_js_test.rb
@@ -8,9 +8,6 @@ module ForemanOvirt
     setup do
       Fog.mock!
       @ovirt_cr = FactoryBot.create(:ovirt_cr)
-
-      @mock_template = FactoryBot.build(:ovirt_template)
-      ForemanOvirt::Ovirt.any_instance.stubs(:template).returns(@mock_template)
     end
 
     teardown do
@@ -29,6 +26,7 @@ module ForemanOvirt
       # Selecting a template triggers a POST to template_selected. The JS handler
       # in ovirt.js receives the response and populates memory and cores via
       # setMemoryInputProps and updateCoresAndSockets.
+      # Fog.mock! intercepts the client calls so no real oVirt connection is made.
       select('hwp_small (base version)', from: 'compute_attribute[vm_attrs][vm_template]')
       wait_for_ajax
 
@@ -39,6 +37,7 @@ module ForemanOvirt
 
       # Reload the form and verify the template values were saved and are
       # rendered back correctly by the server.
+      # hwp_small has memory: 536870912 (512 MB) and cores: 1 per Fog mock data.
       visit compute_profiles_path
       click_link('test')
       click_link(@ovirt_cr.to_s)

--- a/test/integration/compute_profile_js_test.rb
+++ b/test/integration/compute_profile_js_test.rb
@@ -5,22 +5,12 @@ require 'integration_test_helper'
 
 module ForemanOvirt
   class ComputeProfileJSTest < IntegrationTestWithJavascript
-    HWP_SMALL_ATTRS = {
-      id: '2a08ba05-f3b1-4e5a-ade9-496466a8b323',
-      name: 'hwp_small',
-      memory: 536_870_912,
-      cores: 1,
-      sockets: 1,
-      ha: false,
-      interfaces: [],
-      volumes: [],
-    }.freeze
-
     setup do
       Fog.mock!
       @ovirt_cr = FactoryBot.create(:ovirt_cr)
-      mock_template = OpenStruct.new(HWP_SMALL_ATTRS)
-      ForemanOvirt::Ovirt.any_instance.stubs(:template).returns(mock_template)
+
+      @mock_template = FactoryBot.build(:ovirt_template)
+      ForemanOvirt::Ovirt.any_instance.stubs(:template).returns(@mock_template)
     end
 
     teardown do
@@ -33,27 +23,28 @@ module ForemanOvirt
       fill_in('compute_profile_name', with: 'test')
       click_on('Submit')
 
-      assert click_link(@ovirt_cr.to_s), 'Failed to click oVirt compute resource link'
-      assert page.has_select?('compute_attribute[vm_attrs][vm_template]'),
-             'Template select field not found on compute attribute form'
+      click_link(@ovirt_cr.to_s)
+      assert page.has_select?('compute_attribute[vm_attrs][vm_template]')
+
+      # Selecting a template triggers a POST to template_selected. The JS handler
+      # in ovirt.js receives the response and populates memory and cores via
+      # setMemoryInputProps and updateCoresAndSockets.
       select('hwp_small (base version)', from: 'compute_attribute[vm_attrs][vm_template]')
       wait_for_ajax
 
-      assert_equal '512 MB', find_field('compute_attribute_vm_attrs_memory').value,
-                   'Memory should auto-populate from the selected template via AJAX'
-      assert_equal '1', find_field('compute_attribute_vm_attrs_cores').value,
-                   'Cores should auto-populate from the selected template via AJAX'
-
       click_button('Submit')
-      assert_current_path compute_profile_path(ComputeProfile.find_by!(name: 'test'))
+
+      created_profile = ComputeProfile.find_by!(name: 'test')
+      assert_current_path compute_profile_path(created_profile)
+
+      # Reload the form and verify the template values were saved and are
+      # rendered back correctly by the server.
       visit compute_profiles_path
       click_link('test')
-      assert click_link(@ovirt_cr.to_s), 'Failed to click oVirt compute resource link on reload'
+      click_link(@ovirt_cr.to_s)
 
-      assert_equal '512 MB', find_field('compute_attribute_vm_attrs_memory').value,
-                   'Memory should persist as 512 MB after reload'
-      assert_equal '1', find_field('compute_attribute_vm_attrs_cores').value,
-                   'Cores should persist as 1 after reload'
+      assert_equal '512 MB', find_field('compute_attribute_vm_attrs_memory').value
+      assert_equal '1', find_field('compute_attribute_vm_attrs_cores').value
     end
   end
 end

--- a/test/integration/compute_profile_js_test.rb
+++ b/test/integration/compute_profile_js_test.rb
@@ -5,8 +5,22 @@ require 'integration_test_helper'
 
 module ForemanOvirt
   class ComputeProfileJSTest < IntegrationTestWithJavascript
+    HWP_SMALL_ATTRS = {
+      id: '2a08ba05-f3b1-4e5a-ade9-496466a8b323',
+      name: 'hwp_small',
+      memory: 536_870_912,
+      cores: 1,
+      sockets: 1,
+      ha: false,
+      interfaces: [],
+      volumes: [],
+    }.freeze
+
     setup do
       Fog.mock!
+      @ovirt_cr = FactoryBot.create(:ovirt_cr)
+      mock_template = OpenStruct.new(HWP_SMALL_ATTRS)
+      ForemanOvirt::Ovirt.any_instance.stubs(:template).returns(mock_template)
     end
 
     teardown do
@@ -14,58 +28,32 @@ module ForemanOvirt
     end
 
     test 'create compute profile' do
-      @ovirt_cr = FactoryBot.create(:ovirt_cr)
-
-      # Mock templates so they're available in the form dropdown
-      template1 = Struct.new(:id, :full_name).new('tpl1', 'template 1')
-      template2 = Struct.new(:id, :full_name).new('tpl2', 'template 2')
-      ForemanOvirt::Ovirt.any_instance.stubs(:templates).returns([template1, template2])
-
       visit compute_profiles_path
       click_on('Create Compute Profile')
-
-      work_around_selenium_file_detector_bug if respond_to?(:work_around_selenium_file_detector_bug)
-
       fill_in('compute_profile_name', with: 'test')
       click_on('Submit')
 
-      # Click into the oVirt compute resource tab
       assert click_link(@ovirt_cr.to_s), 'Failed to click oVirt compute resource link'
-
-      # Verify the form has the required fields
-      assert page.has_select?('compute_attribute_vm_attrs_vm_template'), 'Template field not found'
-      assert page.has_field?('compute_attribute_vm_attrs_memory'), 'Memory field not found'
-      assert page.has_field?('compute_attribute_vm_attrs_cores'), 'Cores field not found'
-
-      # Select a template
-      select('template 1', from: 'compute_attribute_vm_attrs_vm_template')
+      assert page.has_select?('compute_attribute[vm_attrs][vm_template]'),
+             'Template select field not found on compute attribute form'
+      select('hwp_small (base version)', from: 'compute_attribute[vm_attrs][vm_template]')
       wait_for_ajax
 
-      fill_in('compute_attribute_vm_attrs_memory', with: '512')
-      fill_in('compute_attribute_vm_attrs_cores', with: '2')
+      assert_equal '512 MB', find_field('compute_attribute_vm_attrs_memory').value,
+                   'Memory should auto-populate from the selected template via AJAX'
+      assert_equal '1', find_field('compute_attribute_vm_attrs_cores').value,
+                   'Cores should auto-populate from the selected template via AJAX'
 
       click_button('Submit')
-
-      # A successful form submission redirects from the compute_attributes form
-      # to the compute profile show page at /compute_profiles/:id
-      assert_current_path(%r{/compute_profiles/\d+-test}, ignore_query: true)
-      created_profile = ComputeProfile.find_by(name: 'test')
-      assert_not_nil created_profile, 'Compute profile "test" should be created in database'
-
-      compute_attribute = created_profile.compute_attributes.find_by(compute_resource_id: @ovirt_cr.id)
-      assert_not_nil compute_attribute, 'oVirt compute attributes should be created for this profile'
-      assert_equal '2', compute_attribute.vm_attrs['cores'].to_s, 'Cores should be saved as 2 in the database'
-
-      # Reload the profile and verify the values persisted to the database
+      assert_current_path compute_profile_path(ComputeProfile.find_by!(name: 'test'))
       visit compute_profiles_path
       click_link('test')
       assert click_link(@ovirt_cr.to_s), 'Failed to click oVirt compute resource link on reload'
 
-      memory_value = find_field('compute_attribute_vm_attrs_memory').value
-      cores_value = find_field('compute_attribute_vm_attrs_cores').value
-
-      assert_not memory_value.empty?, 'Memory value should not be empty after reload'
-      assert_equal '2', cores_value, 'Cores value should persist after reload'
+      assert_equal '512 MB', find_field('compute_attribute_vm_attrs_memory').value,
+                   'Memory should persist as 512 MB after reload'
+      assert_equal '1', find_field('compute_attribute_vm_attrs_cores').value,
+                   'Cores should persist as 1 after reload'
     end
   end
 end


### PR DESCRIPTION
When oVirt was extracted from Foreman into this plugin, the integration test covering compute profile creation with an oVirt compute resource was removed from Foreman core but not migrated to the plugin. This PR adds it back.

### What Changed

The test created a compute profile, selected the hwp_small template on the oVirt compute attribute form, submitted, and verified that the template values (512 MB memory, 1 core) were saved and rendered correctly on reload.

Files changed

- test/integration/compute_profile_js_test.rb : migrated test
- test/factories/foreman_ovirt_factories.rb : added :ovirt_template factory representing the mock template object returned by the stubbed #template method

